### PR TITLE
fix: fix hide null icon main bottom bar

### DIFF
--- a/app/src/main/java/com/example/nocket/Navigation.kt
+++ b/app/src/main/java/com/example/nocket/Navigation.kt
@@ -49,7 +49,6 @@ fun Navigation() {
     // Define routes where bottom bar should be hidden
     val hideBottomBarRoutes = setOf(
         Screen.Message.route,
-        // Screen.Camera.route, // No longer needed as we use local camera view
         Screen.Profile.route,
         Screen.Setting.route,
     )
@@ -109,14 +108,6 @@ fun Navigation() {
             composable(Screen.Detail.route) {
                 PlaceholderScreen(title = "Detail",navController =  navController)
             }
-
-            // Camera route is no longer needed as we use local camera view in PostDetailScreen
-            // composable(Screen.Camera.route) {
-            //     CameraScreen(
-            //         onBack = { navController.popBackStack() },
-            //         onPhotoTaken = { navController.popBackStack() }
-            //     )
-            // }
         }
     }
 

--- a/app/src/main/java/com/example/nocket/components/bottombar/MainBottomBar.kt
+++ b/app/src/main/java/com/example/nocket/components/bottombar/MainBottomBar.kt
@@ -58,13 +58,10 @@ private fun normalizeItems(original: List<BottomNavItem>): Pair<List<BottomNavIt
  * Determines which bottom navigation items to show based on the current route
  */
 private fun getBottomNavItems(currentRoute: String?): List<BottomNavItem> {
-    // Note: The camera button's behavior is controlled by the onCameraClick parameter
-    // passed to MainBottomBar, not by the route in the BottomNavItem
     return when (currentRoute) {
         Screen.Home.route -> sampleItems2 // Use sampleItems2 for Home screen
         Screen.Profile.route -> sampleItems // Use full items for Profile screen
         Screen.Setting.route -> sampleItems3 // Use sampleItems3 for Settings screen
-        Screen.Post.route -> sampleItems2 // Use sampleItems2 for Post detail screen
         else -> sampleItems2 // Default to sampleItems2 for other screens
     }
 }
@@ -74,11 +71,9 @@ fun MainBottomBar(
     navController: NavController = rememberNavController(),
     currentRoute: String?,
     items: List<BottomNavItem>? = null, // Make items optional
-    onCameraClick: () -> Unit // No default - caller must provide the camera click behavior
+    onCameraClick: () -> Unit = { navController.navigate(Screen.Camera.route) }
 ) {
     // Use provided items or determine items based on current route
-    // The items determine which buttons are shown, but the onCameraClick parameter
-    // controls what happens when the camera button is clicked
     val navItems = items ?: getBottomNavItems(currentRoute)
     val (orderedItems, centerItem) = normalizeItems(navItems)
 
@@ -87,19 +82,14 @@ fun MainBottomBar(
     ) {
         orderedItems.forEach { item ->
             if (item == centerItem) {
-                // center special button (camera)
+                // center special button (vd: camera)
                 Box(
                     modifier = Modifier
                         .size(56.dp)
                         .align(Alignment.CenterVertically)
                         .background(color = Color.Transparent, shape = CircleShape)
                         .border(width = 2.dp, color = Color.Yellow, shape = CircleShape)
-                        .clickable { 
-                            // Call the provided onCameraClick function instead of navigating
-                            // This will be either the default (navigate to Camera screen)
-                            // or a custom implementation (like setting localCameraMode = true)
-                            onCameraClick() 
-                        },
+                        .clickable { onCameraClick() },
                     contentAlignment = Alignment.Center
                 ) {
                     // Vòng tròn trắng bên trong
@@ -109,7 +99,7 @@ fun MainBottomBar(
                             .background(color = Color.White, shape = CircleShape)
                     )
                 }
-            } else {
+            } else if (item.selectedIcon != null || item.unselectedIcon != null) {
                 NavigationBarItem(
                     icon = {
                         if (item.selectedIcon != null || item.unselectedIcon != null) {
@@ -141,6 +131,9 @@ fun MainBottomBar(
                         }
                     }
                 )
+            } else {
+                // Empty box placeholder with same size as navigation items
+                Box(modifier = Modifier.weight(1f))
             }
         }
     }
@@ -163,7 +156,7 @@ private val sampleItems = listOf(
         title = "Camera",
         selectedIcon = Icons.Filled.CameraAlt,
         unselectedIcon = Icons.Filled.CameraAlt,
-        route = "", // Empty route to prevent navigation and use onCameraClick instead
+        route = "",
         isCenter = true
     ),
     BottomNavItem(
@@ -191,7 +184,7 @@ val sampleItems2 = listOf(
         title = "Camera",
         selectedIcon = Icons.Filled.CameraAlt,
         unselectedIcon = Icons.Filled.CameraAlt,
-        route = "", // Empty route to prevent navigation and use onCameraClick instead
+        route = "",
         isCenter = true
     ),
     BottomNavItem(
@@ -213,7 +206,7 @@ val sampleItems3 = listOf(
         title = "Camera",
         selectedIcon = Icons.Filled.CameraAlt,
         unselectedIcon = Icons.Filled.CameraAlt,
-        route = "", // Empty route to prevent navigation and use onCameraClick instead
+        route = "",
         isCenter = true
     ),
     BottomNavItem(


### PR DESCRIPTION
This pull request refactors the handling of the camera feature in the bottom navigation bar and navigation flow. The main focus is to remove the dedicated camera route and instead rely on a local camera view, simplifying the navigation logic and making the camera button's behavior more flexible and customizable.

Navigation and Camera Route Handling:

* Removed the dedicated `Screen.Camera.route` from both the navigation graph and the set of routes that hide the bottom bar, as the camera feature is now handled locally within screens [[1]](diffhunk://#diff-432011f3ce37fbb75e258602756e48e61d23ffdee75077d8578c59249b75106bL52) [[2]](diffhunk://#diff-432011f3ce37fbb75e258602756e48e61d23ffdee75077d8578c59249b75106bL112-L119).
* The camera button in the bottom navigation bar no longer navigates to a separate camera screen by default; its behavior can now be customized via the `onCameraClick` parameter.

Bottom Navigation Bar Improvements:

* Updated the `MainBottomBar` component so that the camera button's click behavior defaults to navigation but can be overridden, allowing for local camera handling [[1]](diffhunk://#diff-dff536e420d714b43ff3a28a9d677225545b726c7b221171979d4ea1dc361f94L77-L81) [[2]](diffhunk://#diff-dff536e420d714b43ff3a28a9d677225545b726c7b221171979d4ea1dc361f94L90-R92).
* Improved rendering logic for navigation items to display placeholders for items without icons, ensuring consistent layout [[1]](diffhunk://#diff-dff536e420d714b43ff3a28a9d677225545b726c7b221171979d4ea1dc361f94L112-R102) [[2]](diffhunk://#diff-dff536e420d714b43ff3a28a9d677225545b726c7b221171979d4ea1dc361f94R134-R136).

Code Cleanup:

* Removed outdated comments and unused code related to the camera route and navigation, reflecting the new approach.
* Cleaned up the `route` property for camera items in sample lists, clarifying that navigation is not tied to the route field [[1]](diffhunk://#diff-dff536e420d714b43ff3a28a9d677225545b726c7b221171979d4ea1dc361f94L166-R159) [[2]](diffhunk://#diff-dff536e420d714b43ff3a28a9d677225545b726c7b221171979d4ea1dc361f94L194-R187) [[3]](diffhunk://#diff-dff536e420d714b43ff3a28a9d677225545b726c7b221171979d4ea1dc361f94L216-R209).